### PR TITLE
Add custom 404 page

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="de" class="scroll-smooth">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Seite nicht gefunden - Sven Maibaum</title>
+    <meta name="description" content="Die angeforderte Seite konnte nicht gefunden werden.">
+    <link rel="icon" href="assets/favicon.ico" type="image/x-icon">
+
+    <!-- Skript zum initialen Setzen des Themes -->
+    <script>
+        (function () {
+            const savedTheme = localStorage.getItem('theme');
+            const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+            if (savedTheme) {
+                document.documentElement.setAttribute('data-theme', savedTheme);
+            } else if (prefersDark) {
+                document.documentElement.setAttribute('data-theme', 'dark');
+            } else {
+                document.documentElement.setAttribute('data-theme', 'light');
+            }
+        })();
+    </script>
+
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" crossorigin="anonymous" referrerpolicy="no-referrer" />
+    <link rel="stylesheet" href="css/style.css">
+</head>
+<body class="antialiased min-h-screen flex flex-col">
+    <header class="sticky top-0 z-40 glassmorphism shadow-md">
+        <div class="container mx-auto px-6 py-4 flex justify-between items-center">
+            <a href="index.html#home" class="text-xl font-bold gradient-text">Sven Maibaum</a>
+            <button id="theme-toggle" type="button" class="theme-switcher" title="Toggle theme">
+                <svg id="theme-toggle-dark-icon" class="hidden w-5 h-5" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
+                    <path d="M17.293 13.293A8 8 0 016.707 2.707a8.001 8.001 0 1010.586 10.586z"></path>
+                </svg>
+                <svg id="theme-toggle-light-icon" class="hidden w-5 h-5" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
+                    <path d="M10 2a1 1 0 011 1v1a1 1 0 11-2 0V3a1 1 0 011-1zm4 8a4 4 0 11-8 0 4 4 0 018 0zm-.464 4.95l.707.707a1 1 0 001.414-1.414l-.707-.707a1 1 0 00-1.414 1.414zm2.12-10.607a1 1 0 010 1.414l-.706.707a1 1 0 11-1.414-1.414l.707-.707a1 1 0 011.414 0zM17 11a1 1 0 100-2h-1a1 1 0 100 2h1zm-7 4a1 1 0 011 1v1a1 1 0 11-2 0v-1a1 1 0 011-1zM5.05 6.464A1 1 0 106.465 5.05l-.708-.707a1 1 0 00-1.414 1.414l.707.707zm1.414 8.486l-.707.707a1 1 0 01-1.414-1.414l.707-.707a1 1 0 011.414 1.414zM4 11a1 1 0 100-2H3a1 1 0 000 2h1z" fill-rule="evenodd" clip-rule="evenodd"></path>
+                </svg>
+            </button>
+        </div>
+    </header>
+
+    <main class="flex-grow flex items-center justify-center text-center px-6">
+        <div>
+            <h1 class="text-5xl font-extrabold mb-4 gradient-text">404</h1>
+            <p class="text-xl mb-6">Diese Seite existiert leider nicht.</p>
+            <a href="index.html" class="bg-gradient-to-r text-white font-semibold py-3 px-8 rounded-lg text-lg transition duration-300 transform hover:scale-105 inline-block shadow-lg glow-effect">
+                Zurück zur Startseite
+            </a>
+        </div>
+    </main>
+
+    <footer class="py-8 mt-16">
+        <div class="container mx-auto px-6 text-center">
+            <p>&copy; <span id="currentYear404"></span> Sven Maibaum. Alle Rechte vorbehalten.</p>
+        </div>
+    </footer>
+
+    <script src="js/theme.js" defer></script>
+    <script>
+        document.getElementById('currentYear404').textContent = new Date().getFullYear();
+    </script>
+</body>
+</html>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -36,6 +36,12 @@
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
+  <url>
+    <loc>https://www.sven-maibaum.com/404.html</loc>
+    <lastmod>2025-06-03</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>0.1</priority>
+  </url>
   <!-- Die projekt-detail-layout.html wird hier ausgelassen, da sie eine Vorlage ist. -->
   <!-- Falls du weitere Seiten hinzufügst, sollten diese hier ebenfalls eingetragen werden. -->
 </urlset>


### PR DESCRIPTION
## Summary
- add branded 404 page with theme support and link back to home
- reference 404 page in sitemap

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68463eca8c0c8329920302b70e2fe1bf