### PR TITLE
Integrate serverless form validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+# Sven Maibaum Portfolio
+
+This repository contains the static source files for Sven Maibaum's portfolio website.
+
+## Kontaktformular
+
+Das Formular in `index.html` verwendet weiterhin Formspree als Ziel, wird jedoch vor dem Absenden von einer Netlify Function validiert.
+
+1. Beim Laden der Seite wird Googles reCAPTCHA eingebunden, um Spam vorzubeugen.
+2. Beim Absenden fängt `js/contact.js` das Formular ab und sendet die Daten sowie das reCAPTCHA-Token an `/.netlify/functions/validate-form`.
+3. Die Funktion `validate-form` prüft die Felder und verifiziert das reCAPTCHA mit dem geheimen Schlüssel (`RECAPTCHA_SECRET`). Anschließend leitet sie die Daten an Formspree weiter.
+4. Bei Erfolg erhält der Benutzer eine Bestätigung, bei Fehlern eine entsprechende Meldung.
+
+Zum lokalen Testen bleibt das action-Attribut des Formulars erhalten. Für den produktiven Einsatz muss in den Netlify-Einstellungen die Umgebungsvariable `RECAPTCHA_SECRET` gesetzt und der öffentliche Site Key im Formular (`YOUR_RECAPTCHA_SITE_KEY`) hinterlegt werden.

--- a/index.html
+++ b/index.html
@@ -534,7 +534,7 @@
                     direkt.
                 </p>
                 <div class="formspree-form-container">
-                    <form action="https://formspree.io/f/xvgrpazj" class="fs-form" target="_top" method="POST">
+                    <form id="contactForm" action="https://formspree.io/f/xvgrpazj" class="fs-form" target="_top" method="POST">
                         <div class="fs-field">
                             <label class="fs-label" for="name">Ihr Name</label>
                             <input class="fs-input" id="name" name="name" type="text" placeholder="Max Mustermann"
@@ -554,6 +554,7 @@
                                 required></textarea>
                             <p class="fs-description">Was möchten Sie besprechen?</p>
                         </div>
+                        <div class="g-recaptcha" data-sitekey="YOUR_RECAPTCHA_SITE_KEY"></div>
                         <div class="fs-button-group">
                             <button class="fs-button" type="submit">Nachricht Senden</button>
                         </div>
@@ -587,6 +588,8 @@
         </div>
     </footer>
     <script src="js/script.js" defer></script>
+    <script src="js/contact.js" defer></script>
+    <script src="https://www.google.com/recaptcha/api.js" async defer></script>
     <script src="js/theme.js" defer></script>
 </body>
 

--- a/js/contact.js
+++ b/js/contact.js
@@ -1,0 +1,26 @@
+const form = document.getElementById('contactForm');
+if (form) {
+  form.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const formData = new FormData(form);
+    const payload = Object.fromEntries(formData.entries());
+
+    try {
+      const resp = await fetch('/.netlify/functions/validate-form', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+
+      if (resp.ok) {
+        alert('Nachricht erfolgreich gesendet.');
+        form.reset();
+      } else {
+        const data = await resp.json();
+        alert(data.error || 'Fehler beim Senden der Nachricht.');
+      }
+    } catch (err) {
+      alert('Netzwerkfehler. Bitte versuchen Sie es später erneut.');
+    }
+  });
+}

--- a/netlify/functions/validate-form.js
+++ b/netlify/functions/validate-form.js
@@ -1,0 +1,77 @@
+export async function handler(event) {
+  if (event.httpMethod !== 'POST') {
+    return {
+      statusCode: 405,
+      body: 'Method Not Allowed',
+    };
+  }
+
+  let data;
+  try {
+    data = JSON.parse(event.body || '{}');
+  } catch {
+    return {
+      statusCode: 400,
+      body: JSON.stringify({ error: 'Invalid JSON' }),
+    };
+  }
+
+  const { name, email, message, 'g-recaptcha-response': token } = data;
+  if (!name || !email || !message || !token) {
+    return {
+      statusCode: 400,
+      body: JSON.stringify({ error: 'Missing required fields' }),
+    };
+  }
+
+  const secret = process.env.RECAPTCHA_SECRET;
+  try {
+    const verifyResp = await fetch('https://www.google.com/recaptcha/api/siteverify', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: `secret=${secret}&response=${token}`,
+    });
+    const verify = await verifyResp.json();
+    if (!verify.success) {
+      return {
+        statusCode: 400,
+        body: JSON.stringify({ error: 'reCAPTCHA validation failed' }),
+      };
+    }
+  } catch (err) {
+    return {
+      statusCode: 500,
+      body: JSON.stringify({ error: 'Failed to verify reCAPTCHA' }),
+    };
+  }
+
+  try {
+    const formData = new URLSearchParams();
+    formData.append('name', name);
+    formData.append('email', email);
+    formData.append('message', message);
+
+    const formRes = await fetch('https://formspree.io/f/xvgrpazj', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: formData.toString(),
+    });
+
+    if (!formRes.ok) {
+      return {
+        statusCode: 500,
+        body: JSON.stringify({ error: 'Form submission failed' }),
+      };
+    }
+
+    return {
+      statusCode: 200,
+      body: JSON.stringify({ success: true }),
+    };
+  } catch (err) {
+    return {
+      statusCode: 500,
+      body: JSON.stringify({ error: 'Network error' }),
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- add Netlify function for validating contact form submissions
- add client-side script to send form data to the function
- integrate Google reCAPTCHA widget
- document contact form flow in new README

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68463eda0b348329839554d61432529f