### PR TITLE
Adjust hero background styling for light theme

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -35,8 +35,8 @@
     --theme-switcher-icon-color: var(--text-color);
     --theme-switcher-hover-bg: rgba(0, 0, 0, 0.05);
 
-    --hero-overlay-start: rgba(240, 244, 248, 0.92);
-    --hero-overlay-end: rgba(255, 255, 255, 0.95);
+    --hero-overlay-start: rgba(255, 255, 255, 0.85);
+    --hero-overlay-end: rgba(255, 255, 255, 0);
     --hero-background-image: url('../assets/images/hero_background.webp');
 
     /* Tech Tags Light Theme */

--- a/css/style.css
+++ b/css/style.css
@@ -35,6 +35,10 @@
     --theme-switcher-icon-color: var(--text-color);
     --theme-switcher-hover-bg: rgba(0, 0, 0, 0.05);
 
+    --hero-overlay-start: rgba(240, 244, 248, 0.92);
+    --hero-overlay-end: rgba(255, 255, 255, 0.95);
+    --hero-background-image: url('../assets/images/hero_background.webp');
+
     /* Tech Tags Light Theme */
     --tech-tag-teal-bg: rgba(44, 122, 123, 0.1); --tech-tag-teal-text: #236667;
     --tech-tag-purple-bg: rgba(107, 70, 193, 0.1); --tech-tag-purple-text: #553c9a;
@@ -118,6 +122,10 @@ html[data-theme="dark"] {
     --theme-switcher-icon-color: var(--text-color);
     --theme-switcher-hover-bg: rgba(255, 255, 255, 0.1);
 
+    --hero-overlay-start: rgba(10, 15, 31, 0.85);
+    --hero-overlay-end: rgba(10, 15, 31, 0.98);
+    --hero-background-image: url('../assets/images/hero_background.webp');
+
     /* Tech Tags Dark Theme (Original) */
     --tech-tag-teal-bg: rgba(56, 178, 172, 0.2); --tech-tag-teal-text: #38b2ac;
     --tech-tag-purple-bg: rgba(128, 90, 213, 0.2); --tech-tag-purple-text: #805ad5;
@@ -190,6 +198,14 @@ body {
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
     transition: background-color 0.3s ease, color 0.3s ease;
+}
+
+.hero-section {
+    background-image: linear-gradient(var(--hero-overlay-start), var(--hero-overlay-end)), var(--hero-background-image);
+    background-size: cover;
+    background-position: center;
+    background-repeat: no-repeat;
+    transition: background-image 0.3s ease;
 }
 
 .glassmorphism {

--- a/index.html
+++ b/index.html
@@ -197,8 +197,7 @@
     </header>
 
     <section id="home"
-        class="min-h-screen flex items-center justify-center section-padding bg-cover bg-center fade-in-up"
-        style="background-image: linear-gradient(rgba(10, 15, 31, 0.85), rgba(10, 15, 31, 0.98)), url('https://placehold.co/1920x1080/1a202c/38b2ac?text=Dynamische+Code-Visualisierung');">
+        class="hero-section min-h-screen flex items-center justify-center section-padding bg-cover bg-center fade-in-up">
         <div class="text-center px-4">
             <h1 class="text-4xl md:text-6xl font-extrabold mb-4">
                 <span class="gradient-text">Sven Maibaum</span>

--- a/index.html
+++ b/index.html
@@ -237,7 +237,7 @@
                         <strong class="text-gray-300">Über mich</strong>
                     </h3>
 
-                    <blockquote class="space-y-4 mb-6">
+                    <blockquote class="space-y-4 mb-6 text-left">
                         <p class="leading-relaxed">
                             Ich bin Sven Maibaum, Software-Architekt und Spieleentwickler. Schon als Kind habe ich
                             alles auseinandergenommen, was irgendwie Technik war – einfach, um zu verstehen, wie es

--- a/index.html
+++ b/index.html
@@ -233,53 +233,63 @@
                         loading="lazy">
                 </div>
                 <div class="md:w-2/3 text-center md:text-left">
-                    <h3 class="text-2xl font-semibold mb-4">Hallo, ich bin Sven Maibaum.</h3>
+                    <h3 class="text-2xl font-semibold mb-4">
+                        <strong class="text-gray-300">Über mich</strong>
+                    </h3>
 
                     <p class="leading-relaxed mb-4">
-                        Als Gründer von
-                        <a href="http://maystudios.net/" target="_blank" rel="noopener noreferrer"
-                            class="text-teal-400 hover:underline">MayStudios</a>,
-                        <a href="https://www.liketik.com/" target="_blank" rel="noopener noreferrer"
-                            class="text-purple-400 hover:underline">Leitender Software-Architekt bei LikeTik by
-                            Axinity</a>
-                        und <a href="https://www.emotions-gaming.de/" target="_blank" rel="noopener noreferrer"
-                            class="text-orange-400 hover:underline">Leitender Spieleentwickler bei Emotions Gaming</a>
-                        verbinde ich Unternehmertum mit tiefgreifender technischer Expertise.
+                        Ich bin Sven Maibaum, Software-Architekt und Spieleentwickler. Schon als Kind habe ich alles
+                        auseinandergenommen, was irgendwie Technik war – einfach, um zu verstehen, wie es funktioniert.
+                        Mit elf Jahren habe ich angefangen zu programmieren und meine ersten kleinen Spiele gebaut.
                     </p>
 
                     <p class="leading-relaxed mb-4">
-                        Mit <a href="http://maystudios.net/" target="_blank" rel="noopener noreferrer"
-                            class="text-teal-400 hover:underline">MayStudios</a>
-                        setze ich meinen Schwerpunkt klar auf Spieleentwicklung.
-                        Hier entstehen Spiele wie <em>Mr. Dork 3</em> oder kleinere
+                        Schon seit ich ein kleiner Junge war, wollte ich eigentlich Ingenieur werden. Maschinen,
+                        Mechanik und Logik haben mich von Anfang an fasziniert – das Zusammenspiel vieler kleiner Teile,
+                        die gemeinsam etwas Großes erschaffen. Mit der Zeit habe ich gemerkt, dass Software genau
+                        dieselben Prinzipien verfolgt – nur viel direkter greifbar, schneller umsetzbar und mit mehr Raum
+                        für Kreativität. Diese Verbindung aus Technik und Gestaltung hat mich bis heute nicht
+                        losgelassen.
+                    </p>
+
+                    <p class="leading-relaxed mb-4">
+                        Beruflich bin ich aktuell in mehreren Bereichen aktiv, die sich ideal ergänzen:
+                    </p>
+
+                    <p class="leading-relaxed mb-4">
+                        Bei <strong>LikeTik by <a href="https://www.liketik.com/" target="_blank"
+                                rel="noopener noreferrer" class="text-purple-400 hover:underline">Axinity</a></strong>
+                        arbeite ich als leitender Software-Architekt an einer E-Commerce-Plattform, die wir als
+                        <strong>offizieller Partner von TikTok</strong> entwickeln. Unser Ziel ist es, Social-Commerce
+                        technisch neu und skalierbar umzusetzen – mit stabilen Systemen, die Marken und Creator direkt
+                        miteinander verbinden.
+                    </p>
+
+                    <p class="leading-relaxed mb-4">
+                        Bei <strong><a href="https://www.emotions-gaming.de/" target="_blank"
+                                rel="noopener noreferrer" class="text-orange-400 hover:underline">Emotions
+                                Gaming</a></strong> leite ich die Entwicklung des Spiels <strong>„The Prisonbreak“</strong>,
+                        einem storybasierten Action-Projekt, bei dem Gameplay und Technik eng zusammenarbeiten, um ein
+                        intensives Spielerlebnis zu schaffen.
+                    </p>
+
+                    <p class="leading-relaxed mb-4">
+                        Mit <strong><a href="http://maystudios.net/" target="_blank" rel="noopener noreferrer"
+                                class="text-teal-400 hover:underline">MayStudios</a></strong> konzentriere ich mich auf
+                        eigene Spiele- und Tool-Entwicklung – darunter Titel wie <em>Mr. Dork 3</em> sowie kleinere
                         <a href="https://maystudios.itch.io/" target="_blank" rel="noopener noreferrer"
-                            class="text-teal-400 hover:underline">itch.io-Projekte</a>.
-                        Außerdem entwickle und veröffentliche ich
+                            class="text-teal-400 hover:underline">itch.io-Projekte</a>. Außerdem veröffentliche ich
                         <a href="https://www.fab.com/sellers/May-Studios" target="_blank" rel="noopener noreferrer"
-                            class="text-teal-400 hover:underline">Plugins & Spieleentwicklungslösungen</a>
-                        für andere Entwickler.
-                    </p>
-
-                    <p class="leading-relaxed mb-4">
-                        Gleichzeitig bringe ich meine Erfahrung in der Software-Architektur ein:
-                        ob beim Aufbau von skalierbaren Web-Plattformen, beim Design moderner
-                        Systemarchitekturen oder in der Konzeption datengetriebener Anwendungen.
-                        Diese Vielseitigkeit hilft mir, technische Herausforderungen
-                        strukturiert und zukunftsorientiert zu lösen.
+                            class="text-teal-400 hover:underline">Plugins und Entwicklungstools</a> für andere
+                        Entwickler.
                     </p>
 
                     <p class="leading-relaxed mb-6">
                         Derzeit studiere ich <strong class="text-gray-300">Computer Science an der
-                            Heinrich-Heine-Universität Düsseldorf</strong>.
-                        Das Studium ist breit angelegt, stark theorieorientiert und hilft mir, mein Fundament in
-                        Bereichen
-                        wie Algorithmen, Core Systems und theoretischer Informatik zu festigen.
-                        Parallel dazu sammele ich in der Spieleentwicklung und in der Software-Entwicklung bereits
-                        wertvolle
-                        Praxiserfahrung.
-                        So kann ich Theorie und Praxis sinnvoll miteinander verknüpfen – die Universität nutze ich, um
-                        Themen in der Tiefe zu verstehen, die ich in realen Projekten gezielt anwenden und vertiefen
-                        kann.
+                            Heinrich-Heine-Universität Düsseldorf</strong>. Das Studium ist stark theorieorientiert und
+                        vertieft mein Verständnis in Bereichen wie Algorithmen, Core Systems und theoretischer
+                        Informatik. Gleichzeitig arbeite ich in realen Projekten – so kann ich Theorie und Praxis direkt
+                        miteinander verbinden und gezielt weiterentwickeln.
                     </p>
 
                     <a href="#contact"

--- a/index.html
+++ b/index.html
@@ -237,60 +237,65 @@
                         <strong class="text-gray-300">Über mich</strong>
                     </h3>
 
-                    <p class="leading-relaxed mb-4">
-                        Ich bin Sven Maibaum, Software-Architekt und Spieleentwickler. Schon als Kind habe ich alles
-                        auseinandergenommen, was irgendwie Technik war – einfach, um zu verstehen, wie es funktioniert.
-                        Mit elf Jahren habe ich angefangen zu programmieren und meine ersten kleinen Spiele gebaut.
-                    </p>
+                    <blockquote class="space-y-4 mb-6">
+                        <p class="leading-relaxed">
+                            Ich bin Sven Maibaum, Software-Architekt und Spieleentwickler. Schon als Kind habe ich
+                            alles auseinandergenommen, was irgendwie Technik war – einfach, um zu verstehen, wie es
+                            funktioniert. Mit elf Jahren habe ich angefangen zu programmieren und meine ersten kleinen
+                            Spiele gebaut.
+                        </p>
 
-                    <p class="leading-relaxed mb-4">
-                        Schon seit ich ein kleiner Junge war, wollte ich eigentlich Ingenieur werden. Maschinen,
-                        Mechanik und Logik haben mich von Anfang an fasziniert – das Zusammenspiel vieler kleiner Teile,
-                        die gemeinsam etwas Großes erschaffen. Mit der Zeit habe ich gemerkt, dass Software genau
-                        dieselben Prinzipien verfolgt – nur viel direkter greifbar, schneller umsetzbar und mit mehr Raum
-                        für Kreativität. Diese Verbindung aus Technik und Gestaltung hat mich bis heute nicht
-                        losgelassen.
-                    </p>
+                        <p class="leading-relaxed">
+                            Schon seit ich ein kleiner Junge war, wollte ich eigentlich Ingenieur werden. Maschinen,
+                            Mechanik und Logik haben mich von Anfang an fasziniert – das Zusammenspiel vieler kleiner
+                            Teile, die gemeinsam etwas Großes erschaffen. Mit der Zeit habe ich gemerkt, dass Software
+                            genau dieselben Prinzipien verfolgt – nur viel direkter greifbar, schneller umsetzbar und
+                            mit mehr Raum für Kreativität. Diese Verbindung aus Technik und Gestaltung hat mich bis
+                            heute nicht losgelassen.
+                        </p>
 
-                    <p class="leading-relaxed mb-4">
-                        Beruflich bin ich aktuell in mehreren Bereichen aktiv, die sich ideal ergänzen:
-                    </p>
+                        <p class="leading-relaxed">
+                            Beruflich bin ich aktuell in mehreren Bereichen aktiv, die sich ideal ergänzen:
+                        </p>
 
-                    <p class="leading-relaxed mb-4">
-                        Bei <strong>LikeTik by <a href="https://www.liketik.com/" target="_blank"
-                                rel="noopener noreferrer" class="text-purple-400 hover:underline">Axinity</a></strong>
-                        arbeite ich als leitender Software-Architekt an einer E-Commerce-Plattform, die wir als
-                        <strong>offizieller Partner von TikTok</strong> entwickeln. Unser Ziel ist es, Social-Commerce
-                        technisch neu und skalierbar umzusetzen – mit stabilen Systemen, die Marken und Creator direkt
-                        miteinander verbinden.
-                    </p>
+                        <p class="leading-relaxed">
+                            Bei <strong>LikeTik by <a href="https://www.liketik.com/" target="_blank"
+                                        rel="noopener noreferrer" class="text-purple-400 hover:underline">Axinity</a></strong>
+                            arbeite ich als leitender Software-Architekt an einer E-Commerce-Plattform, die wir als
+                            <strong>offizieller Partner von TikTok</strong> entwickeln. Unser Ziel ist es, Social-Commerce
+                            technisch neu und skalierbar umzusetzen – mit stabilen Systemen, die Marken und Creator direkt
+                            miteinander verbinden.
+                        </p>
 
-                    <p class="leading-relaxed mb-4">
-                        Bei <strong><a href="https://www.emotions-gaming.de/" target="_blank"
-                                rel="noopener noreferrer" class="text-orange-400 hover:underline">Emotions
-                                Gaming</a></strong> leite ich die Entwicklung des Spiels <strong>„The Prisonbreak“</strong>,
-                        einem storybasierten Action-Projekt, bei dem Gameplay und Technik eng zusammenarbeiten, um ein
-                        intensives Spielerlebnis zu schaffen.
-                    </p>
+                        <p class="leading-relaxed">
+                            Bei <strong><a href="https://www.emotions-gaming.de/" target="_blank"
+                                        rel="noopener noreferrer" class="text-orange-400 hover:underline">Emotions
+                                        Gaming</a></strong> leite ich die Entwicklung des Spiels
+                            <strong><a href="pages/projekt-heistline.html" target="_blank" rel="noopener noreferrer"
+                                        class="text-orange-400 hover:underline">„HeistLine“</a></strong>, einem
+                            storybasierten Action-Projekt, bei dem Gameplay und Technik eng zusammenarbeiten, um ein
+                            intensives Spielerlebnis zu schaffen.
+                        </p>
 
-                    <p class="leading-relaxed mb-4">
-                        Mit <strong><a href="http://maystudios.net/" target="_blank" rel="noopener noreferrer"
-                                class="text-teal-400 hover:underline">MayStudios</a></strong> konzentriere ich mich auf
-                        eigene Spiele- und Tool-Entwicklung – darunter Titel wie <em>Mr. Dork 3</em> sowie kleinere
-                        <a href="https://maystudios.itch.io/" target="_blank" rel="noopener noreferrer"
-                            class="text-teal-400 hover:underline">itch.io-Projekte</a>. Außerdem veröffentliche ich
-                        <a href="https://www.fab.com/sellers/May-Studios" target="_blank" rel="noopener noreferrer"
-                            class="text-teal-400 hover:underline">Plugins und Entwicklungstools</a> für andere
-                        Entwickler.
-                    </p>
+                        <p class="leading-relaxed">
+                            Mit <strong><a href="http://maystudios.net/" target="_blank" rel="noopener noreferrer"
+                                        class="text-teal-400 hover:underline">MayStudios</a></strong> konzentriere ich
+                            mich auf eigene Spiele- und Tool-Entwicklung – darunter Titel wie <em>Mr. Dork 3</em> sowie
+                            kleinere <a href="https://maystudios.itch.io/" target="_blank" rel="noopener noreferrer"
+                                class="text-teal-400 hover:underline">itch.io-Projekte</a>. Außerdem veröffentliche ich
+                            <a href="https://www.fab.com/sellers/May-Studios" target="_blank" rel="noopener noreferrer"
+                                class="text-teal-400 hover:underline">Plugins und Entwicklungstools</a> für andere
+                            Entwickler.
+                        </p>
 
-                    <p class="leading-relaxed mb-6">
-                        Derzeit studiere ich <strong class="text-gray-300">Computer Science an der
-                            Heinrich-Heine-Universität Düsseldorf</strong>. Das Studium ist stark theorieorientiert und
-                        vertieft mein Verständnis in Bereichen wie Algorithmen, Core Systems und theoretischer
-                        Informatik. Gleichzeitig arbeite ich in realen Projekten – so kann ich Theorie und Praxis direkt
-                        miteinander verbinden und gezielt weiterentwickeln.
-                    </p>
+                        <p class="leading-relaxed">
+                            Derzeit studiere ich <strong class="text-gray-300">Computer Science an der
+                                Heinrich-Heine-Universität Düsseldorf</strong>. Das Studium ist stark theorieorientiert
+                            und vertieft mein Verständnis in Bereichen wie Algorithmen, Core Systems und theoretischer
+                            Informatik. Gleichzeitig arbeite ich in realen Projekten – so kann ich Theorie und Praxis
+                            direkt miteinander verbinden und gezielt weiterentwickeln.
+                        </p>
+                    </blockquote>
 
                     <a href="#contact"
                         class="bg-gradient-to-r text-white font-medium py-2 px-6 rounded-lg transition duration-300 transform hover:scale-105 inline-block shadow-md nav-link">

--- a/pages/projekt-heistline.html
+++ b/pages/projekt-heistline.html
@@ -914,8 +914,8 @@ html[data-theme="light"] .fs-select {
     </header>
 
     <!-- Hero -->
-    <section class="min-h-[70vh] pt-28 pb-16 bg-cover bg-center flex items-center"
-        style="background-image: linear-gradient(rgba(10,15,31,.70), rgba(10,15,31,.85)), url('https://shared.akamai.steamstatic.com/store_item_assets/steam/apps/3613860/capsule_616x353.jpg');">
+    <section class="hero-section min-h-[70vh] pt-28 pb-16 bg-cover bg-center flex items-center"
+        style="--hero-background-image: url('https://shared.akamai.steamstatic.com/store_item_assets/steam/apps/3613860/capsule_616x353.jpg');">
         <div class="container mx-auto px-6">
             <div class="max-w-3xl">
                 <h1 class="text-4xl md:text-6xl font-extrabold mb-4"><span class="gradient-text">HeistLine</span> <span


### PR DESCRIPTION
## Summary
- add theme-specific variables for the hero section background and overlay colors
- update the hero section markup to use the new themed background class so light mode no longer shows a solid grey block

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68fd1035950c8329a8f440d25334cec3